### PR TITLE
Change Help-Customizing's "Restart $[software}" to "Restart Grid"

### DIFF
--- a/Resources/GridHelp/pgs/usage-customizing.html
+++ b/Resources/GridHelp/pgs/usage-customizing.html
@@ -51,7 +51,7 @@
 </li>
 			
 <li type="square">
-<font face="Lucida Grande,Geneva,Arial">Restart $[software} if necessary.</font>
+<font face="Lucida Grande,Geneva,Arial">Restart Grid if necessary.</font>
 </li>
 			
 <li type="square">


### PR DESCRIPTION
"Restart $[software}" looks wrong to me and I assume "Grid" was meant to be put there. It looks like this originated in a script and typo that generate help pages.
